### PR TITLE
[#6] 특정 부서에 속한 사원의 급여를 특정 비율로 인상할 수 있다

### DIFF
--- a/src/main/java/kr/rogarithm/econrich/domain/department/controller/DepartmentController.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/controller/DepartmentController.java
@@ -1,0 +1,27 @@
+package kr.rogarithm.econrich.domain.department.controller;
+
+import kr.rogarithm.econrich.domain.department.service.DepartmentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/departments")
+public class DepartmentController {
+
+    private final DepartmentService departmentService;
+
+    public DepartmentController(DepartmentService departmentService) {
+        this.departmentService = departmentService;
+    }
+
+    @PutMapping("")
+    public ResponseEntity<Void> raiseSalaryOfDepartment(
+            @RequestParam Long departmentId,
+            @RequestParam Double raiseRate) {
+        departmentService.raiseSalaryOfDepartment(departmentId, raiseRate);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/kr/rogarithm/econrich/domain/department/controller/DepartmentController.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/controller/DepartmentController.java
@@ -1,5 +1,7 @@
 package kr.rogarithm.econrich.domain.department.controller;
 
+import java.util.List;
+import kr.rogarithm.econrich.domain.department.dto.RaiseDepartmentSalaryResponse;
 import kr.rogarithm.econrich.domain.department.service.DepartmentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -18,10 +20,11 @@ public class DepartmentController {
     }
 
     @PutMapping("")
-    public ResponseEntity<Void> raiseSalaryOfDepartment(
+    public ResponseEntity<List<RaiseDepartmentSalaryResponse>> raiseSalaryOfDepartment(
             @RequestParam Long departmentId,
             @RequestParam Double raiseRate) {
-        departmentService.raiseSalaryOfDepartment(departmentId, raiseRate);
-        return ResponseEntity.ok().build();
+        List<RaiseDepartmentSalaryResponse> responses = departmentService.raiseSalaryOfDepartment(departmentId,
+                raiseRate);
+        return ResponseEntity.ok().body(responses);
     }
 }

--- a/src/main/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapper.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapper.java
@@ -3,9 +3,12 @@ package kr.rogarithm.econrich.domain.department.dao;
 import java.util.List;
 import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface DepartmentMapper {
 
     List<JobHistory> selectJobHistories(Long departmentId);
+
+    Integer updateEmployeeSalary(@Param("employeeId") Long employeeId, @Param("raiseRate") Double raiseRate);
 }

--- a/src/main/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapper.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapper.java
@@ -1,5 +1,6 @@
 package kr.rogarithm.econrich.domain.department.dao;
 
+import java.math.BigDecimal;
 import java.util.List;
 import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
 import org.apache.ibatis.annotations.Mapper;
@@ -11,4 +12,6 @@ public interface DepartmentMapper {
     List<JobHistory> selectJobHistories(Long departmentId);
 
     Integer updateEmployeeSalary(@Param("employeeId") Long employeeId, @Param("raiseRate") Double raiseRate);
+
+    BigDecimal selectEmployeeSalary(Long employeeId);
 }

--- a/src/main/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapper.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapper.java
@@ -1,10 +1,11 @@
 package kr.rogarithm.econrich.domain.department.dao;
 
+import java.util.List;
 import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface DepartmentMapper {
 
-    JobHistory selectJobHistoryById(Long departmentId);
+    List<JobHistory> selectJobHistories(Long departmentId);
 }

--- a/src/main/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapper.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapper.java
@@ -1,0 +1,10 @@
+package kr.rogarithm.econrich.domain.department.dao;
+
+import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface DepartmentMapper {
+
+    JobHistory selectJobHistoryById(Long departmentId);
+}

--- a/src/main/java/kr/rogarithm/econrich/domain/department/dto/RaiseDepartmentSalaryResponse.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/dto/RaiseDepartmentSalaryResponse.java
@@ -1,0 +1,14 @@
+package kr.rogarithm.econrich.domain.department.dto;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class RaiseDepartmentSalaryResponse {
+
+    Long employeeId;
+    BigDecimal salaryBefore;
+    BigDecimal salaryAfter;
+}

--- a/src/main/java/kr/rogarithm/econrich/domain/department/exception/InvalidRaiseRateException.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/exception/InvalidRaiseRateException.java
@@ -1,0 +1,8 @@
+package kr.rogarithm.econrich.domain.department.exception;
+
+public class InvalidRaiseRateException extends RuntimeException {
+
+    public InvalidRaiseRateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
@@ -1,7 +1,10 @@
 package kr.rogarithm.econrich.domain.department.service;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import kr.rogarithm.econrich.domain.department.dao.DepartmentMapper;
+import kr.rogarithm.econrich.domain.department.dto.RaiseDepartmentSalaryResponse;
 import kr.rogarithm.econrich.domain.department.exception.InvalidRaiseRateException;
 import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
 import kr.rogarithm.econrich.domain.employee.exception.DepartmentNotFoundException;
@@ -18,7 +21,7 @@ public class DepartmentService {
     }
 
     @Transactional
-    public Integer raiseSalaryOfDepartment(Long departmentId, Double raiseRate) {
+    public List<RaiseDepartmentSalaryResponse> raiseSalaryOfDepartment(Long departmentId, Double raiseRate) {
 
         if (raiseRate < 0) {
             throw new InvalidRaiseRateException("유효하지 않은 급여 인상률 " + raiseRate + "을 입력하셨습니다. 급여 인상률은 0보다 커야 합니다");
@@ -30,12 +33,22 @@ public class DepartmentService {
             throw new DepartmentNotFoundException("입력한 부서 아이디 " + departmentId + "에 해당하는 부서를 찾을 수 없습니다");
         }
 
-        Integer updatedRows = 0;
+        List<RaiseDepartmentSalaryResponse> result = new ArrayList<>();
         for (JobHistory jobHistory : jobHistories) {
-            Integer updated = departmentMapper.updateEmployeeSalary(jobHistory.getEmployeeId(), raiseRate);
-            updatedRows += updated;
+            Long employeeId = jobHistory.getEmployeeId();
+            BigDecimal salaryBefore = departmentMapper.selectEmployeeSalary(employeeId);
+
+            departmentMapper.updateEmployeeSalary(employeeId, raiseRate);
+
+            BigDecimal salaryAfter = departmentMapper.selectEmployeeSalary(employeeId);
+            RaiseDepartmentSalaryResponse response = RaiseDepartmentSalaryResponse.builder()
+                                                                                  .employeeId(employeeId)
+                                                                                  .salaryBefore(salaryBefore)
+                                                                                  .salaryAfter(salaryAfter)
+                                                                                  .build();
+            result.add(response);
         }
 
-        return updatedRows;
+        return result;
     }
 }

--- a/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
@@ -5,7 +5,9 @@ import kr.rogarithm.econrich.domain.department.dao.DepartmentMapper;
 import kr.rogarithm.econrich.domain.department.exception.InvalidRaiseRateException;
 import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
 import kr.rogarithm.econrich.domain.employee.exception.DepartmentNotFoundException;
+import org.springframework.stereotype.Service;
 
+@Service
 public class DepartmentService {
 
     private final DepartmentMapper departmentMapper;

--- a/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
@@ -6,6 +6,7 @@ import kr.rogarithm.econrich.domain.department.exception.InvalidRaiseRateExcepti
 import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
 import kr.rogarithm.econrich.domain.employee.exception.DepartmentNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class DepartmentService {
@@ -16,6 +17,7 @@ public class DepartmentService {
         this.departmentMapper = departmentMapper;
     }
 
+    @Transactional
     public Integer raiseSalaryOfDepartment(Long departmentId, Double raiseRate) {
 
         if (raiseRate < 0) {

--- a/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
@@ -1,0 +1,7 @@
+package kr.rogarithm.econrich.domain.department.service;
+
+public class DepartmentService {
+
+    public Integer raiseSalaryOfDepartment(Long departmentId, Double raiseRate) {
+    }
+}

--- a/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
@@ -2,6 +2,7 @@ package kr.rogarithm.econrich.domain.department.service;
 
 import java.util.List;
 import kr.rogarithm.econrich.domain.department.dao.DepartmentMapper;
+import kr.rogarithm.econrich.domain.department.exception.InvalidRaiseRateException;
 import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
 import kr.rogarithm.econrich.domain.employee.exception.DepartmentNotFoundException;
 
@@ -14,6 +15,11 @@ public class DepartmentService {
     }
 
     public Integer raiseSalaryOfDepartment(Long departmentId, Double raiseRate) {
+
+        if (raiseRate < 0) {
+            throw new InvalidRaiseRateException("유효하지 않은 급여 인상률 " + raiseRate + "을 입력하셨습니다. 급여 인상률은 0보다 커야 합니다");
+        }
+
         List<JobHistory> jobHistories = departmentMapper.selectJobHistories(departmentId);
 
         if (jobHistories.isEmpty()) {

--- a/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
@@ -1,7 +1,25 @@
 package kr.rogarithm.econrich.domain.department.service;
 
+import java.util.List;
+import kr.rogarithm.econrich.domain.department.dao.DepartmentMapper;
+import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
+import kr.rogarithm.econrich.domain.employee.exception.DepartmentNotFoundException;
+
 public class DepartmentService {
 
+    private final DepartmentMapper departmentMapper;
+
+    public DepartmentService(DepartmentMapper departmentMapper) {
+        this.departmentMapper = departmentMapper;
+    }
+
     public Integer raiseSalaryOfDepartment(Long departmentId, Double raiseRate) {
+        List<JobHistory> jobHistories = departmentMapper.selectJobHistories(departmentId);
+
+        if (jobHistories.isEmpty()) {
+            throw new DepartmentNotFoundException("입력한 부서 아이디 " + departmentId + "에 해당하는 부서를 찾을 수 없습니다");
+        }
+
+        return 0;
     }
 }

--- a/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/department/service/DepartmentService.java
@@ -26,6 +26,12 @@ public class DepartmentService {
             throw new DepartmentNotFoundException("입력한 부서 아이디 " + departmentId + "에 해당하는 부서를 찾을 수 없습니다");
         }
 
-        return 0;
+        Integer updatedRows = 0;
+        for (JobHistory jobHistory : jobHistories) {
+            Integer updated = departmentMapper.updateEmployeeSalary(jobHistory.getEmployeeId(), raiseRate);
+            updatedRows += updated;
+        }
+
+        return updatedRows;
     }
 }

--- a/src/main/java/kr/rogarithm/econrich/domain/employee/controller/EmployeeController.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/employee/controller/EmployeeController.java
@@ -37,4 +37,5 @@ public class EmployeeController {
         DepartmentResponse department = employeeService.getDepartmentById(employeeId);
         return ResponseEntity.ok().body(department);
     }
+
 }

--- a/src/main/java/kr/rogarithm/econrich/domain/employee/domain/JobHistory.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/employee/domain/JobHistory.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 public class JobHistory {
 
-    private Long id;
+    private Long employeeId;
     private LocalDate startDate;
     private LocalDate endDate;
     private String jobId;

--- a/src/main/java/kr/rogarithm/econrich/domain/employee/dto/JobHistoryResponse.java
+++ b/src/main/java/kr/rogarithm/econrich/domain/employee/dto/JobHistoryResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 public class JobHistoryResponse {
 
-    private Long id;
+    private Long employeeId;
     private LocalDate startDate;
     private LocalDate endDate;
     private String jobId;
@@ -17,7 +17,7 @@ public class JobHistoryResponse {
 
     public static JobHistoryResponse of(JobHistory jobHistory) {
         return JobHistoryResponse.builder()
-                                 .id(jobHistory.getId())
+                                 .employeeId(jobHistory.getEmployeeId())
                                  .startDate(jobHistory.getStartDate())
                                  .endDate(jobHistory.getEndDate())
                                  .jobId(jobHistory.getJobId())

--- a/src/main/java/kr/rogarithm/econrich/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/rogarithm/econrich/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package kr.rogarithm.econrich.global.exception;
 
+import kr.rogarithm.econrich.domain.department.exception.InvalidRaiseRateException;
 import kr.rogarithm.econrich.domain.employee.exception.DepartmentNotFoundException;
 import kr.rogarithm.econrich.domain.employee.exception.EmployeeNotFoundException;
 import kr.rogarithm.econrich.domain.employee.exception.JobHistoryNotFoundException;
@@ -24,5 +25,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DepartmentNotFoundException.class)
     protected ResponseEntity<Void> departmentNotFoundException(DepartmentNotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+
+    @ExceptionHandler(InvalidRaiseRateException.class)
+    protected ResponseEntity<Void> invalidRaiseRateException(InvalidRaiseRateException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
     }
 }

--- a/src/main/resources/mybatis/mapper/DepartmentMapper.xml
+++ b/src/main/resources/mybatis/mapper/DepartmentMapper.xml
@@ -17,6 +17,10 @@
     UPDATE employees
     SET salary = salary * #{raiseRate}
     WHERE employee_id = #{employeeId};
+  <select id="selectEmployeeSalary" parameterType="Long" resultType="BigDecimal">
+    SELECT salary
+    FROM employees
+    WHERE employee_id = #{employeeId};
   </select>
 
 </mapper>

--- a/src/main/resources/mybatis/mapper/DepartmentMapper.xml
+++ b/src/main/resources/mybatis/mapper/DepartmentMapper.xml
@@ -13,10 +13,12 @@
     WHERE department_id = #{departmentId}
   </select>
 
-  <select id="updateEmployeeSalary" resultType="Integer">
+  <update id="updateEmployeeSalary">
     UPDATE employees
     SET salary = salary * #{raiseRate}
     WHERE employee_id = #{employeeId};
+  </update>
+
   <select id="selectEmployeeSalary" parameterType="Long" resultType="BigDecimal">
     SELECT salary
     FROM employees

--- a/src/main/resources/mybatis/mapper/DepartmentMapper.xml
+++ b/src/main/resources/mybatis/mapper/DepartmentMapper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="kr.rogarithm.econrich.domain.department.dao.DepartmentMapper">
+
+  <select id="selectJobHistoryById" parameterType="Long"
+    resultType="kr.rogarithm.econrich.domain.employee.domain.JobHistory">
+    SELECT
+    employee_id, start_date, end_date, job_id, department_id
+    FROM job_history
+    WHERE department_id = #{departmentId}
+  </select>
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/DepartmentMapper.xml
+++ b/src/main/resources/mybatis/mapper/DepartmentMapper.xml
@@ -13,4 +13,10 @@
     WHERE department_id = #{departmentId}
   </select>
 
+  <select id="updateEmployeeSalary" resultType="Integer">
+    UPDATE employees
+    SET salary = salary * #{raiseRate}
+    WHERE employee_id = #{employeeId};
+  </select>
+
 </mapper>

--- a/src/main/resources/mybatis/mapper/DepartmentMapper.xml
+++ b/src/main/resources/mybatis/mapper/DepartmentMapper.xml
@@ -5,7 +5,7 @@
 
 <mapper namespace="kr.rogarithm.econrich.domain.department.dao.DepartmentMapper">
 
-  <select id="selectJobHistoryById" parameterType="Long"
+  <select id="selectJobHistories" parameterType="Long"
     resultType="kr.rogarithm.econrich.domain.employee.domain.JobHistory">
     SELECT
     employee_id, start_date, end_date, job_id, department_id

--- a/src/test/java/kr/rogarithm/econrich/domain/department/controller/DepartmentControllerTest.java
+++ b/src/test/java/kr/rogarithm/econrich/domain/department/controller/DepartmentControllerTest.java
@@ -1,0 +1,45 @@
+package kr.rogarithm.econrich.domain.department.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import kr.rogarithm.econrich.domain.department.service.DepartmentService;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = DepartmentController.class)
+class DepartmentControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @InjectMocks
+    DepartmentController departmentController;
+
+    @MockBean
+    DepartmentService departmentService;
+
+    @Test
+    public void raiseRateOfDepartment() throws Exception {
+        Long id = 100L;
+        Double raiseRate = 1.1;
+
+        when(departmentService.raiseSalaryOfDepartment(id, raiseRate)).thenReturn(1);
+
+        this.mockMvc
+                .perform(put("/departments")
+                        .param("departmentId", id.toString())
+                        .param("raiseRate", raiseRate.toString()))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(departmentService).raiseSalaryOfDepartment(id, raiseRate);
+    }
+}

--- a/src/test/java/kr/rogarithm/econrich/domain/department/controller/DepartmentControllerTest.java
+++ b/src/test/java/kr/rogarithm/econrich/domain/department/controller/DepartmentControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import kr.rogarithm.econrich.domain.department.service.DepartmentService;
+import kr.rogarithm.econrich.domain.employee.exception.DepartmentNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,6 +40,23 @@ class DepartmentControllerTest {
                         .param("raiseRate", raiseRate.toString()))
                 .andDo(print())
                 .andExpect(status().isOk());
+
+        verify(departmentService).raiseSalaryOfDepartment(id, raiseRate);
+    }
+
+    @Test
+    public void raiseRateOfNonExistingDepartment() throws Exception {
+        Long id = -1L;
+        Double raiseRate = 1.1;
+
+        when(departmentService.raiseSalaryOfDepartment(id, raiseRate)).thenThrow(DepartmentNotFoundException.class);
+
+        this.mockMvc
+                .perform(put("/departments")
+                        .param("departmentId", id.toString())
+                        .param("raiseRate", raiseRate.toString()))
+                .andDo(print())
+                .andExpect(status().isNotFound());
 
         verify(departmentService).raiseSalaryOfDepartment(id, raiseRate);
     }

--- a/src/test/java/kr/rogarithm/econrich/domain/department/controller/DepartmentControllerTest.java
+++ b/src/test/java/kr/rogarithm/econrich/domain/department/controller/DepartmentControllerTest.java
@@ -6,6 +6,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import kr.rogarithm.econrich.domain.department.dto.RaiseDepartmentSalaryResponse;
 import kr.rogarithm.econrich.domain.department.exception.InvalidRaiseRateException;
 import kr.rogarithm.econrich.domain.department.service.DepartmentService;
 import kr.rogarithm.econrich.domain.employee.exception.DepartmentNotFoundException;
@@ -31,9 +35,15 @@ class DepartmentControllerTest {
     @Test
     public void raiseRateOfDepartment() throws Exception {
         Long id = 100L;
-        Double raiseRate = 1.1;
+        Double raiseRate = 2.0;
+        List<RaiseDepartmentSalaryResponse> responses = new ArrayList<>();
+        responses.add(RaiseDepartmentSalaryResponse.builder()
+                                                   .employeeId(id)
+                                                   .salaryBefore(BigDecimal.valueOf(4400.00))
+                                                   .salaryAfter(BigDecimal.valueOf(8800.00))
+                                                   .build());
 
-        when(departmentService.raiseSalaryOfDepartment(id, raiseRate)).thenReturn(1);
+        when(departmentService.raiseSalaryOfDepartment(id, raiseRate)).thenReturn(responses);
 
         this.mockMvc
                 .perform(put("/departments")

--- a/src/test/java/kr/rogarithm/econrich/domain/department/controller/DepartmentControllerTest.java
+++ b/src/test/java/kr/rogarithm/econrich/domain/department/controller/DepartmentControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import kr.rogarithm.econrich.domain.department.exception.InvalidRaiseRateException;
 import kr.rogarithm.econrich.domain.department.service.DepartmentService;
 import kr.rogarithm.econrich.domain.employee.exception.DepartmentNotFoundException;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,23 @@ class DepartmentControllerTest {
                         .param("raiseRate", raiseRate.toString()))
                 .andDo(print())
                 .andExpect(status().isNotFound());
+
+        verify(departmentService).raiseSalaryOfDepartment(id, raiseRate);
+    }
+
+    @Test
+    public void raiseRateOfInvalidRate() throws Exception {
+        Long id = 100L;
+        Double raiseRate = -1.1;
+
+        when(departmentService.raiseSalaryOfDepartment(id, raiseRate)).thenThrow(InvalidRaiseRateException.class);
+
+        this.mockMvc
+                .perform(put("/departments")
+                        .param("departmentId", id.toString())
+                        .param("raiseRate", raiseRate.toString()))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
 
         verify(departmentService).raiseSalaryOfDepartment(id, raiseRate);
     }

--- a/src/test/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapperTest.java
+++ b/src/test/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapperTest.java
@@ -1,0 +1,29 @@
+package kr.rogarithm.econrich.domain.department.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DepartmentMapperTest {
+
+    @Autowired
+    DepartmentMapper departmentMapper;
+
+    @Test
+    public void selectJobHistoryByInvalidId() {
+        JobHistory jobHistory = departmentMapper.selectJobHistoryById(-1L);
+
+        assertEquals(null, jobHistory);
+    }
+
+    @Test
+    public void selectJobHistoryWithOneJobIdByValidId() {
+        JobHistory jobHistory = departmentMapper.selectJobHistoryById(60L);
+
+        assertEquals(60L, jobHistory.getDepartmentId());
+    }
+}

--- a/src/test/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapperTest.java
+++ b/src/test/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapperTest.java
@@ -3,8 +3,12 @@ package kr.rogarithm.econrich.domain.department.dao;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
+import kr.rogarithm.econrich.domain.employee.domain.Employee;
 import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -36,5 +40,31 @@ class DepartmentMapperTest {
         for (JobHistory jobHistory : jobHistories) {
             assertEquals(110L, jobHistory.getDepartmentId());
         }
+    }
+
+    @Test
+    public void updateSalaryOfOneEmployee() {
+        BigDecimal salaryBeforeRaise = BigDecimal.valueOf(4400.00);
+        Employee employee = Employee.builder()
+                                    .id(200L)
+                                    .firstName("Jennifer")
+                                    .lastName("Whalen")
+                                    .email("JWHALEN")
+                                    .phoneNumber("515.123.4444")
+                                    .hireDate(LocalDate.parse("1987-09-17"))
+                                    .jobId("AD_ASST")
+                                    .salary(salaryBeforeRaise)
+                                    .commissionPct(BigDecimal.valueOf(101))
+                                    .departmentId(10L)
+                                    .build();
+
+        Integer updatedRow = departmentMapper.updateEmployeeSalary(employee.getId(), 2.0);
+        BigDecimal salaryAfterRaise = departmentMapper.selectEmployeeSalary(employee.getId());
+
+        Assertions.assertThat(updatedRow).isEqualTo(1);
+        Assertions.assertThat(salaryAfterRaise).isEqualTo(salaryBeforeRaise.multiply(BigDecimal.valueOf(2.0)));
+
+        // rollback
+        departmentMapper.updateEmployeeSalary(employee.getId(), 0.5);
     }
 }

--- a/src/test/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapperTest.java
+++ b/src/test/java/kr/rogarithm/econrich/domain/department/dao/DepartmentMapperTest.java
@@ -1,7 +1,9 @@
 package kr.rogarithm.econrich.domain.department.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,15 +17,24 @@ class DepartmentMapperTest {
 
     @Test
     public void selectJobHistoryByInvalidId() {
-        JobHistory jobHistory = departmentMapper.selectJobHistoryById(-1L);
+        List<JobHistory> jobHistories = departmentMapper.selectJobHistories(-1L);
 
-        assertEquals(null, jobHistory);
+        assertTrue(jobHistories.isEmpty());
     }
 
     @Test
     public void selectJobHistoryWithOneJobIdByValidId() {
-        JobHistory jobHistory = departmentMapper.selectJobHistoryById(60L);
+        List<JobHistory> jobHistories = departmentMapper.selectJobHistories(60L);
 
-        assertEquals(60L, jobHistory.getDepartmentId());
+        assertEquals(60L, jobHistories.get(0).getDepartmentId());
+    }
+
+    @Test
+    public void selectJobHistoryWithTwoJobIdByValidId() {
+        List<JobHistory> jobHistories = departmentMapper.selectJobHistories(110L);
+
+        for (JobHistory jobHistory : jobHistories) {
+            assertEquals(110L, jobHistory.getDepartmentId());
+        }
     }
 }

--- a/src/test/java/kr/rogarithm/econrich/domain/department/service/DepartmentServiceTest.java
+++ b/src/test/java/kr/rogarithm/econrich/domain/department/service/DepartmentServiceTest.java
@@ -1,18 +1,23 @@
 package kr.rogarithm.econrich.domain.department.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import kr.rogarithm.econrich.domain.department.dao.DepartmentMapper;
+import kr.rogarithm.econrich.domain.department.dto.RaiseDepartmentSalaryResponse;
 import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 @ExtendWith(MockitoExtension.class)
 class DepartmentServiceTest {
@@ -27,25 +32,45 @@ class DepartmentServiceTest {
     public void updateSalaryOfOneEmployee() {
         // given
         Long departmentId = 90L;
-        Double raiseRate = 1.1;
+        Double raiseRate = 2.0;
+        Long employeeId = 100L;
 
         JobHistory jobHistory = JobHistory.builder()
-                                          .employeeId(100L)
+                                          .employeeId(employeeId)
                                           .startDate(LocalDate.parse("1987-09-17"))
                                           .endDate(LocalDate.parse("1993-06-17"))
                                           .jobId("AD_ASST")
                                           .departmentId(90L)
                                           .build();
-
+        List<RaiseDepartmentSalaryResponse> responses = new ArrayList<>();
+        responses.add(RaiseDepartmentSalaryResponse.builder()
+                                                   .employeeId(100L)
+                                                   .salaryBefore(BigDecimal.valueOf(4400.00))
+                                                   .salaryAfter(BigDecimal.valueOf(8800.00))
+                                                   .build());
         // when
         when(departmentMapper.selectJobHistories(departmentId)).thenReturn(List.of(jobHistory));
-        when(departmentMapper.updateEmployeeSalary(jobHistory.getEmployeeId(), raiseRate)).thenReturn(1);
-        Integer result = departmentService.raiseSalaryOfDepartment(departmentId, raiseRate);
+        when(departmentMapper.updateEmployeeSalary(employeeId, raiseRate)).thenReturn(1);
+        when(departmentMapper.selectEmployeeSalary(employeeId)).thenAnswer(new Answer() {
+            private int count = 0;
+
+            public Object answer(InvocationOnMock invocation) {
+                if (++count == 1) {
+                    return BigDecimal.valueOf(4400.00);
+                } else {
+                    return BigDecimal.valueOf(8800.00);
+                }
+            }
+        });
+
+        List<RaiseDepartmentSalaryResponse> result = departmentService.raiseSalaryOfDepartment(departmentId, raiseRate);
 
         // then
         verify(departmentMapper).selectJobHistories(departmentId);
-        verify(departmentMapper).updateEmployeeSalary(jobHistory.getEmployeeId(), raiseRate);
-        assertEquals(1, result);
+        verify(departmentMapper).updateEmployeeSalary(employeeId, raiseRate);
+        Assertions.assertThat(result.get(0).getEmployeeId()).isEqualTo(responses.get(0).getEmployeeId());
+        Assertions.assertThat(result.get(0).getSalaryBefore()).isEqualTo(responses.get(0).getSalaryBefore());
+        Assertions.assertThat(result.get(0).getSalaryAfter()).isEqualTo(responses.get(0).getSalaryAfter());
     }
 
     @Test
@@ -54,31 +79,73 @@ class DepartmentServiceTest {
         Long departmentId = 90L;
         Double raiseRate = 1.1;
 
+        Long employeeOneId = 100L;
         JobHistory jobHistory1 = JobHistory.builder()
-                                           .employeeId(100L)
+                                           .employeeId(employeeOneId)
                                            .startDate(LocalDate.parse("1987-09-17"))
                                            .endDate(LocalDate.parse("1993-06-17"))
                                            .jobId("AD_ASST")
-                                           .departmentId(90L)
+                                           .departmentId(departmentId)
                                            .build();
+        Long employeeTwoId = 101L;
         JobHistory jobHistory2 = JobHistory.builder()
-                                           .employeeId(101L)
+                                           .employeeId(employeeTwoId)
                                            .startDate(LocalDate.parse("1994-07-01"))
                                            .endDate(LocalDate.parse("1998-12-31"))
                                            .jobId("AC_ACCOUNT")
-                                           .departmentId(90L)
+                                           .departmentId(departmentId)
                                            .build();
 
+        List<RaiseDepartmentSalaryResponse> responses = new ArrayList<>();
+        responses.add(RaiseDepartmentSalaryResponse.builder()
+                                                   .employeeId(employeeOneId)
+                                                   .salaryBefore(BigDecimal.valueOf(4400.00))
+                                                   .salaryAfter(BigDecimal.valueOf(8800.00))
+                                                   .build());
+        responses.add(RaiseDepartmentSalaryResponse.builder()
+                                                   .employeeId(employeeTwoId)
+                                                   .salaryBefore(BigDecimal.valueOf(4400.00))
+                                                   .salaryAfter(BigDecimal.valueOf(8800.00))
+                                                   .build());
         // when
         when(departmentMapper.selectJobHistories(departmentId)).thenReturn(List.of(jobHistory1, jobHistory2));
         when(departmentMapper.updateEmployeeSalary(jobHistory1.getEmployeeId(), raiseRate)).thenReturn(1);
         when(departmentMapper.updateEmployeeSalary(jobHistory2.getEmployeeId(), raiseRate)).thenReturn(1);
-        Integer result = departmentService.raiseSalaryOfDepartment(departmentId, raiseRate);
+        when(departmentMapper.selectEmployeeSalary(employeeOneId)).thenAnswer(new Answer() {
+            private int count = 0;
+
+            public Object answer(InvocationOnMock invocation) {
+                if (++count == 1) {
+                    return BigDecimal.valueOf(4400.00);
+                } else {
+                    return BigDecimal.valueOf(8800.00);
+                }
+            }
+        });
+        when(departmentMapper.selectEmployeeSalary(employeeTwoId)).thenAnswer(new Answer() {
+            private int count = 0;
+
+            public Object answer(InvocationOnMock invocation) {
+                if (++count == 1) {
+                    return BigDecimal.valueOf(4400.00);
+                } else {
+                    return BigDecimal.valueOf(8800.00);
+                }
+            }
+        });
+
+        List<RaiseDepartmentSalaryResponse> result = departmentService.raiseSalaryOfDepartment(departmentId,
+                raiseRate);
 
         // then
         verify(departmentMapper).selectJobHistories(departmentId);
         verify(departmentMapper).updateEmployeeSalary(jobHistory1.getEmployeeId(), raiseRate);
         verify(departmentMapper).updateEmployeeSalary(jobHistory2.getEmployeeId(), raiseRate);
-        assertEquals(2, result);
+        Assertions.assertThat(result.get(0).getEmployeeId()).isEqualTo(responses.get(0).getEmployeeId());
+        Assertions.assertThat(result.get(0).getSalaryBefore()).isEqualTo(responses.get(0).getSalaryBefore());
+        Assertions.assertThat(result.get(0).getSalaryAfter()).isEqualTo(responses.get(0).getSalaryAfter());
+        Assertions.assertThat(result.get(1).getEmployeeId()).isEqualTo(responses.get(1).getEmployeeId());
+        Assertions.assertThat(result.get(1).getSalaryBefore()).isEqualTo(responses.get(1).getSalaryBefore());
+        Assertions.assertThat(result.get(1).getSalaryAfter()).isEqualTo(responses.get(1).getSalaryAfter());
     }
 }

--- a/src/test/java/kr/rogarithm/econrich/domain/department/service/DepartmentServiceTest.java
+++ b/src/test/java/kr/rogarithm/econrich/domain/department/service/DepartmentServiceTest.java
@@ -1,0 +1,84 @@
+package kr.rogarithm.econrich.domain.department.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+import kr.rogarithm.econrich.domain.department.dao.DepartmentMapper;
+import kr.rogarithm.econrich.domain.employee.domain.JobHistory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DepartmentServiceTest {
+
+    @InjectMocks
+    DepartmentService departmentService;
+
+    @Mock
+    DepartmentMapper departmentMapper;
+
+    @Test
+    public void updateSalaryOfOneEmployee() {
+        // given
+        Long departmentId = 90L;
+        Double raiseRate = 1.1;
+
+        JobHistory jobHistory = JobHistory.builder()
+                                          .employeeId(100L)
+                                          .startDate(LocalDate.parse("1987-09-17"))
+                                          .endDate(LocalDate.parse("1993-06-17"))
+                                          .jobId("AD_ASST")
+                                          .departmentId(90L)
+                                          .build();
+
+        // when
+        when(departmentMapper.selectJobHistories(departmentId)).thenReturn(List.of(jobHistory));
+        when(departmentMapper.updateEmployeeSalary(jobHistory.getEmployeeId(), raiseRate)).thenReturn(1);
+        Integer result = departmentService.raiseSalaryOfDepartment(departmentId, raiseRate);
+
+        // then
+        verify(departmentMapper).selectJobHistories(departmentId);
+        verify(departmentMapper).updateEmployeeSalary(jobHistory.getEmployeeId(), raiseRate);
+        assertEquals(1, result);
+    }
+
+    @Test
+    public void updateSalaryOfTwoEmployee() {
+        // given
+        Long departmentId = 90L;
+        Double raiseRate = 1.1;
+
+        JobHistory jobHistory1 = JobHistory.builder()
+                                           .employeeId(100L)
+                                           .startDate(LocalDate.parse("1987-09-17"))
+                                           .endDate(LocalDate.parse("1993-06-17"))
+                                           .jobId("AD_ASST")
+                                           .departmentId(90L)
+                                           .build();
+        JobHistory jobHistory2 = JobHistory.builder()
+                                           .employeeId(101L)
+                                           .startDate(LocalDate.parse("1994-07-01"))
+                                           .endDate(LocalDate.parse("1998-12-31"))
+                                           .jobId("AC_ACCOUNT")
+                                           .departmentId(90L)
+                                           .build();
+
+        // when
+        when(departmentMapper.selectJobHistories(departmentId)).thenReturn(List.of(jobHistory1, jobHistory2));
+        when(departmentMapper.updateEmployeeSalary(jobHistory1.getEmployeeId(), raiseRate)).thenReturn(1);
+        when(departmentMapper.updateEmployeeSalary(jobHistory2.getEmployeeId(), raiseRate)).thenReturn(1);
+        Integer result = departmentService.raiseSalaryOfDepartment(departmentId, raiseRate);
+
+        // then
+        verify(departmentMapper).selectJobHistories(departmentId);
+        verify(departmentMapper).updateEmployeeSalary(jobHistory1.getEmployeeId(), raiseRate);
+        verify(departmentMapper).updateEmployeeSalary(jobHistory2.getEmployeeId(), raiseRate);
+        assertEquals(2, result);
+    }
+}

--- a/src/test/java/kr/rogarithm/econrich/domain/employee/controller/EmployeeControllerTest.java
+++ b/src/test/java/kr/rogarithm/econrich/domain/employee/controller/EmployeeControllerTest.java
@@ -96,7 +96,7 @@ class EmployeeControllerTest {
     public void getJobHistoryWithValidId() throws Exception {
         Long id = 101L;
         JobHistory jobHistory = JobHistory.builder()
-                                          .id(101L)
+                                          .employeeId(101L)
                                           .startDate(LocalDate.parse("1989-09-21"))
                                           .endDate(LocalDate.parse("1993-10-27"))
                                           .jobId("AC_ACCOUNT")

--- a/src/test/java/kr/rogarithm/econrich/domain/employee/dao/EmployeeMapperTest.java
+++ b/src/test/java/kr/rogarithm/econrich/domain/employee/dao/EmployeeMapperTest.java
@@ -41,7 +41,7 @@ class EmployeeMapperTest {
     public void selectJobHistoryByValidId() {
         JobHistory jobHistory = employeeMapper.selectJobHistoryById(102L);
 
-        assertEquals(102L, jobHistory.getId());
+        assertEquals(102L, jobHistory.getEmployeeId());
     }
 
     @Test

--- a/src/test/java/kr/rogarithm/econrich/domain/employee/service/EmployeeServiceTest.java
+++ b/src/test/java/kr/rogarithm/econrich/domain/employee/service/EmployeeServiceTest.java
@@ -80,7 +80,7 @@ class EmployeeServiceTest {
         // given
         Long id = 101L;
         JobHistory jobHistory = JobHistory.builder()
-                                          .id(101L)
+                                          .employeeId(101L)
                                           .startDate(LocalDate.parse("1989-09-21"))
                                           .endDate(LocalDate.parse("1993-10-27"))
                                           .jobId("AC_ACCOUNT")
@@ -95,7 +95,7 @@ class EmployeeServiceTest {
         // then
         verify(employeeMapper).selectJobHistoryById(id);
         assertNotNull(jobHistoryResponse);
-        assertEquals(id, jobHistoryResponse.getId());
+        assertEquals(id, jobHistoryResponse.getEmployeeId());
     }
 
     @Test


### PR DESCRIPTION
#### 작업 내용
- 특정 부서에 속한 모든 사원의 급여를 특정 비율로 인상하는 API를 추가한다
- API의 응답으로 급여를 바꾼 사원에 대한 [사원 아이디, 변경 전 급여, 변경 후 급여]를 DTO로 만들어 반환한다
- 입력한 부서 아이디에 속한 사원이 여러 명이라면, 사원 모두의 급여를 바꾸고, 응답은 리스트로 제공한다

#### 설계 관련 고민
- 처음에는 update에 성공한 행 갯수만 응답으로 제공하도록 구현했다
- 하지만 API를 쓰는 입장에서 다소 불편할 것 같았고, 바뀐 내용을 응답으로 전달하는 게 더 낫다고 생각해 변경했다